### PR TITLE
タイムゾーンの設定を追加した

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module PixPick
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.

--- a/m-a
+++ b/m-a
@@ -1,0 +1,1 @@
+local   pix_pick_production all                                     md5


### PR DESCRIPTION
関連Issue：#66 環境設定の初期調整
`config/application.rb`にタイムゾーンに関する設定を追加した。