### PR TITLE
コンテスト画面のUIを改善した

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -92,18 +92,6 @@ button {
     background-color: darkred;
 }
 
-.image-gallery {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(150px, 150px)); /* 最小150px、最大で等分割 */
-    gap: 10px;
-    padding: 10px;
-}
-
-.image-gallery img {
-    width: 100%;
-    object-fit: contain;
-}
-
 .loading-spinner {
     display: none;
 }

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -8,9 +8,7 @@ class VotesController < ApplicationController
     if @vote.save
       broadcast_vote_feedback
     else
-      render turbo_stream: append_turbo_toast(:error,
-                                              t('activerecord.errors.messages.save',
-                                                model: t('activerecord.models.vote')))
+      render turbo_stream: append_turbo_toast(:error, @vote.errors.full_messages.to_sentence)
     end
   end
 

--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -31,6 +31,10 @@ class Contest < ApplicationRecord
     false
   end
 
+  def deadline_passed?
+    deadline.end_of_day.past?
+  end
+
   private
 
   def deadline_cannot_be_in_the_past

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -5,4 +5,13 @@ class Vote < ApplicationRecord
   belongs_to :entry
 
   validates :entry_id, uniqueness: { scope: :user_id }
+  validate :contest_must_be_open_for_voting
+
+  private
+
+  def contest_must_be_open_for_voting
+    return unless entry.contest.deadline.end_of_day.past?
+
+    errors.add(:base, 'このコンテストは投票期日を過ぎているため投票できません')
+  end
 end

--- a/app/views/contests/_all_entries.html.slim
+++ b/app/views/contests/_all_entries.html.slim
@@ -1,3 +1,9 @@
+- if @contest.deadline_passed?
+  .text-center.my-6.text-lg.font-semibold.text-gray-700
+    | このコンテストは投票を締め切りました。
+    br
+    | ランキングタブから投票結果をご確認ください。
+
 = render 'entries/thumbnail_list'
 
 = link_to new_contest_entry_path(@contest),

--- a/app/views/contests/show.html.slim
+++ b/app/views/contests/show.html.slim
@@ -13,7 +13,8 @@ h1.text-2xl.font-bold.text-center.mt-4 = @contest.name
       data: { turbo_frame: 'content' },
       class: tab_link_classes(request.fullpath,
                               ranking_contest_path(@contest),
-                              'w-32 h-10 leading-10 px-2 font-bold text-center')
+                              'w-32 h-10 leading-10 px-2 font-bold text-center \
+                               bg-gray-100 hover:bg-white')
 
   - if current_page?(contest_path(@contest))
     = render 'contests/all_entries'

--- a/app/views/contests/show.html.slim
+++ b/app/views/contests/show.html.slim
@@ -1,4 +1,11 @@
-h1.text-2xl.font-bold.text-center.mt-4 = @contest.name
+.flex.justify-between.items-center.bg-gray-100.px-4.py-3
+  .overflow-hidden
+    h1.text-2xl.font-bold.my-2.truncate = @contest.name
+    p.text-base.text-gray-600 投票期日：#{@contest.deadline.strftime('%Y年%-m月%-d日')}
+
+  = link_to '編集', edit_contest_path(@contest),
+    class: 'bg-gray-300 text-gray-700 hover:bg-gray-400 hover:text-black \
+            py-2 w-20 text-center rounded text-lg font-semibold flex-shrink-0'
 
 = turbo_frame_tag 'content' do
   div class='flex justify-center items-center mt-6 \

--- a/app/views/entries/_score.slim
+++ b/app/views/entries/_score.slim
@@ -1,5 +1,5 @@
 = turbo_frame_tag "score_#{entry_id}"
   - if score.present?
-    .absolute.top-0.right-1.bg-cyan-500.text-white.rounded-full
+    .absolute.-top-1.-right-2.bg-cyan-500.text-white.rounded-full
       .w-6.h-6.flex.items-center.justify-center.text-sm.font-bold
         = score

--- a/app/views/entries/_thumbnail_list.html.slim
+++ b/app/views/entries/_thumbnail_list.html.slim
@@ -1,20 +1,25 @@
-.image-gallery data-controller="modal"
-  dialog(
-    data-modal-target="dialog"
-    class="px-4 py-8 rounded-lg backdrop:bg-black/80"
-  )
-    .modal-content data-modal-target="content"
+- if @entry_scores.any?
+  .w-full.px-4
+    .grid.grid-cols-2.sm:grid-cols-4.gap-2.mx-auto.mt-4 data-controller="modal"
+      dialog(
+        data-modal-target="dialog"
+        class="px-4 py-8 rounded-lg backdrop:bg-black/80"
+      )
+        .modal-content data-modal-target="content"
 
-  - @entry_scores.each do |entry_id, score|
-    = turbo_frame_tag "entry_#{entry_id}"
-      .relative
-        - entries_show_url = contest_entry_path(@contest.id, entry_id)
-        = button_tag type: 'button',
-          data: { action: 'click->modal#open',
-                  modal_entries_show_url_value: entries_show_url },
-          class: 'thumbnail-button text-white font-bold py-2 px-4 rounded'
-          = image_tag thumbnail_contest_entry_path(@contest, entry_id),
-            alt: t('views.entries.alt_text'),
-            class: 'w-full h-auto'
+      - @entry_scores.each do |entry_id, score|
+        = turbo_frame_tag "entry_#{entry_id}",
+          class: 'flex justify-center items-center'
+          .relative
+            - entries_show_url = contest_entry_path(@contest.id, entry_id)
+            = button_tag type: 'button',
+              data: { action: 'click->modal#open',
+                modal_entries_show_url_value: entries_show_url },
+              class: 'thumbnail-button text-white font-bold py-2 rounded'
+              = image_tag thumbnail_contest_entry_path(@contest, entry_id),
+                alt: t('views.entries.alt_text'),
+                class: 'w-full h-auto'
 
-        = render 'entries/score', entry_id: entry_id, score: score
+            = render 'entries/score', entry_id: entry_id, score: score
+- else
+  p.mt-8.text-center.text-gray-600 エントリーがありません。


### PR DESCRIPTION
- Resolve #39
- Resolve #140 

コンテスト画面に次の機能を追加し、レイアウトを調整した。
- セクションヘッダーを追加
- 投票期日を過ぎた場合の対応
	- ランキングへの案内テキストが出るようにした
	- Voteモデルにバリデーションを設定した