### PR TITLE
set_contestを共通化した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,15 +5,15 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   before_action :authenticate_user!
   before_action :set_recent_contests
-  before_action :set_selected_contest
+  before_action :set_contest
 
   private
 
-  def set_selected_contest
+  def set_contest
     contest_id = params[:contest_id] || params[:id]
     return unless user_signed_in? && contest_id.present?
 
-    @selected_contest_name = Contest.find(contest_id)&.name
+    @contest = Contest.find(contest_id)
   end
 
   def set_recent_contests

--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -4,7 +4,6 @@ class ContestsController < ApplicationController
   include GoogleApiActions
 
   before_action :ensure_valid_access_token!, only: %i[show ranking create update]
-  before_action :set_contest, only: %i[show ranking edit update invite destroy]
   before_action :set_drive_service, only: %i[show ranking create update]
 
   def index
@@ -96,10 +95,6 @@ class ContestsController < ApplicationController
 
   def contest_params
     params.require(:contest).permit(:name, :deadline)
-  end
-
-  def set_contest
-    @contest = Contest.find(params[:id])
   end
 
   def redirect_with_failure

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -4,7 +4,6 @@ class EntriesController < ApplicationController
   include GoogleApiActions
 
   before_action :ensure_valid_access_token!, only: %i[image_proxy create destroy]
-  before_action :set_contest, only: %i[show new create]
   before_action :set_entry, only: %i[thumbnail_proxy show image_proxy destroy]
   before_action :set_drive_service, only: %i[thumbnail_proxy image_proxy create destroy]
 
@@ -92,10 +91,6 @@ class EntriesController < ApplicationController
 
   def files_params
     params.permit(files: [])
-  end
-
-  def set_contest
-    @contest = Contest.find(params[:contest_id])
   end
 
   def set_entry

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class ParticipantsController < ApplicationController
-  before_action :set_contest, only: %i[new create destroy]
   skip_before_action :authenticate_user!, only: :new
 
   def new
@@ -42,11 +41,5 @@ class ParticipantsController < ApplicationController
         append_turbo_toast(:success, '参加を取り消しました')
       ]
     end
-  end
-
-  private
-
-  def set_contest
-    @contest = Contest.find(params[:contest_id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  skip_before_action :set_selected_contest, only: :destroy
+  skip_before_action :set_contest, only: :destroy
 
   def destroy
     current_user.destroy!

--- a/app/views/shared/_contest_selection.html.slim
+++ b/app/views/shared/_contest_selection.html.slim
@@ -13,8 +13,10 @@
            bg-white px-2 sm:px-4 py-2 rounded-md truncate \
            hover:ring-2 focus:outline-none focus:ring-2 focus:ring-cyan-500'
   )
-    = @selected_contest_name.presence \
-      || t('views.layouts.header.select_contest')
+    - if @contest.present?
+      = @contest.name
+    - else
+      = t('views.layouts.header.select_contest')
     .ml-1.sm:ml-2.i.fa-solid.fa-chevron-down
   div(
     data-dropdown-target='menu'


### PR DESCRIPTION
ヘッダーの`contest_selection`で選択中のコンテストオブジェクトを取得するため、リソースコントローラーでもそれを利用する形にした。