### PR TITLE
コンテストを削除するとGoogleドライブ上のフォルダも削除されるようにした

### DIFF
--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -4,7 +4,7 @@ class ContestsController < ApplicationController
   include GoogleApiActions
 
   before_action :ensure_valid_access_token!, only: %i[show ranking create update]
-  before_action :set_drive_service, only: %i[show ranking update]
+  before_action :set_drive_service, only: %i[show ranking update destroy]
 
   def index
     @contests = current_user.contests
@@ -84,7 +84,8 @@ class ContestsController < ApplicationController
   end
 
   def destroy
-    @contest.destroy
+    @contest.destroy_with_drive_folder(@drive_service)
+
     redirect_to user_contests_path(current_user), notice: 'コンテストが削除されました。'
   end
 

--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -72,6 +72,13 @@ class Contest < ApplicationRecord
     deadline.end_of_day.past?
   end
 
+  def destroy_with_drive_folder(drive_service)
+    transaction do
+      drive_service.delete_file(drive_file_id)
+      destroy!
+    end
+  end
+
   private
 
   def deadline_cannot_be_in_the_past

--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -59,7 +59,7 @@ class Contest < ApplicationRecord
   end
 
   def save_drive_ids(folder_id, permission_id)
-    ActiveRecord::Base.transaction do
+    transaction do
       self.drive_file_id = folder_id
       self.drive_permission_id = permission_id
       save!

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -19,7 +19,7 @@ class Entry < ApplicationRecord
   ALLOWED_MIME_TYPES = %w[image/jpeg image/jpg image/png image/webp image/heic image/heif].freeze
 
   def self.upload_and_create_entries!(file_info, current_user, contest, drive_service)
-    ActiveRecord::Base.transaction do
+    transaction do
       drive_file_id, permission_id = upload_to_google_drive(file_info, contest.drive_file_id, drive_service)
 
       create!(


### PR DESCRIPTION
- Resolves #179 