### PR TITLE
Google Drive APIのスコープを変更した

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -274,7 +274,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   config.omniauth :google_oauth2, ENV.fetch('GOOGLE_CLIENT_ID', nil), ENV.fetch('GOOGLE_CLIENT_SECRET', nil),
-                  scope: 'profile, drive',
+                  scope: 'profile, drive.file',
                   access_type: 'offline',
                   prompt: 'consent'
 


### PR DESCRIPTION
Google Drive APIが制限付きのスコープになっていたので、非機密性のスコープへ変更した。
これに伴い、操作できるアイテムがGoogleドライブ上の全ファイルから、アプリから作成したファイルのみに変更となった。