### PR TITLE
一度にアップロードできるファイル数を10枚までに制限した

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,6 @@ RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
     chown -R rails:rails db log tmp && \
     apt-get update -qq && apt-get install -y \
-        imagemagick \
         libvips \
         node-gyp \
         python-is-python3

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -14,6 +14,11 @@ class EntriesController < ApplicationController
   def create
     files = files_params[:files]
 
+    if files.size > 10
+      render json: { error: 'アップロードできる写真の最大数は10枚です' }, status: :unprocessable_entity
+      return
+    end
+
     error_message = validate_files(files)
     if error_message.present?
       render json: { error: error_message }, status: :unprocessable_entity

--- a/app/javascript/controllers/file_entry_controller.js
+++ b/app/javascript/controllers/file_entry_controller.js
@@ -223,9 +223,7 @@ export default class extends Controller {
 
     if (this.files.length === 0) {
       alert("アップロードするファイルを選択してください。");
-      this.uploadButtonTarget.disabled = false;
-      this.uploadButtonTarget.innerHTML = originalButtonText;
-      document.body.classList.remove("loading");
+      this.resetUploadButton(originalButtonText);
       return;
     }
 
@@ -250,10 +248,18 @@ export default class extends Controller {
         window.location.href = responseData.redirect_url;
       } else {
         alert(responseData.error || "アップロードに失敗しました。");
+        this.resetUploadButton(originalButtonText);
       }
     } catch (error) {
       console.error("Upload error:", error);
       alert("通信エラーが発生しました。");
+      this.resetUploadButton(originalButtonText);
     }
+  }
+
+  resetUploadButton(originalText) {
+    this.uploadButtonTarget.disabled = false;
+    this.uploadButtonTarget.innerHTML = originalText;
+    document.body.classList.remove("loading");
   }
 }

--- a/app/views/entries/new.html.slim
+++ b/app/views/entries/new.html.slim
@@ -29,6 +29,9 @@
     )
     .preview-container.mt-4 data-file-entry-target='preview'
 
+  .text-sm.font-bold.text-stone-500.text-center.sm:text-right.mt-2
+    | ※一度にアップロードできる写真の枚数は10枚までです。
+
   .sm:hidden.mt-6
     label(
       class="block w-full h-14 bg-white text-stone-500 font-bold \

--- a/fly.toml
+++ b/fly.toml
@@ -49,7 +49,7 @@ secrets = ["REDIS_URL"]
 [[vm]]
   processes = ["app"]
   size = "shared-cpu-1x"
-  memory = 512
+  memory = 1024
 
 [[vm]]
   processes = ["sidekiq"]


### PR DESCRIPTION
- Resolves #235 

メモリ不足によるサーバのクラッシュを防止するため、一度にアップロードできるファイル数を10枚までに制限した。