### PR TITLE
現在のRubyバージョンに対応するようDockerfileを修正した

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM base AS build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libpq-dev pkg-config && \
+    apt-get install --no-install-recommends -y build-essential git libpq-dev pkg-config libyaml-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems
@@ -44,9 +44,6 @@ RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
-
-
-
 
 # Final stage for app image
 FROM base


### PR DESCRIPTION
Ruby3.4.1にしたらDockerのビルドでpsychがインストールできずコケるようになったので対応した。

- [Revert "Remove runtime dependencies from slim and alpine variants" by Earlopain · Pull Request \#497 · docker\-library/ruby](https://github.com/docker-library/ruby/pull/497)
- [Ruby3\.1 ~ 3\.4でDocker buildでpsychのインストールで失敗する \#Ruby \- Qiita](https://qiita.com/tatematsu-k/items/d68e19c8a90b2599baf2)

【原因】
[Remove runtime dependencies from slim and alpine variants by tianon · Pull Request \#493 · docker\-library/ruby](https://github.com/docker-library/ruby/pull/493)