### PR TITLE
allow_browser versions: :modernのコメントアウトを外した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  # allow_browser versions: :modern
+  allow_browser versions: :modern
   before_action :authenticate_user!
   before_action :set_recent_contests
   before_action :set_contest


### PR DESCRIPTION
- Resolves #270 

レビュー用にコメントアウトしていた`allow_browser versions: :modern`を元に戻した。