### PR TITLE
Rails8における現行Deviseのバグ対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
       dotenv (= 3.1.8)
       railties (>= 6.1)
     drb (2.2.1)
+    erb (5.0.1)
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
@@ -252,7 +253,7 @@ GEM
     prettier_print (1.2.1)
     prettyprint (0.2.0)
     prism (1.4.0)
-    psych (5.2.3)
+    psych (5.2.6)
       date
       stringio
     public_suffix (6.0.1)
@@ -307,7 +308,8 @@ GEM
     rake (13.2.1)
     rbs (3.9.2)
       logger
-    rdoc (6.13.1)
+    rdoc (6.14.1)
+      erb
       psych (>= 4.0.0)
     redis-client (0.24.0)
       connection_pool
@@ -423,7 +425,7 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
-    stringio (3.1.6)
+    stringio (3.1.7)
     syntax_tree (6.2.0)
       prettier_print (>= 1.2.0)
     syntax_tree-haml (4.0.3)

--- a/config/initializers/devise_rails8_patch.rb
+++ b/config/initializers/devise_rails8_patch.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'devise'
+
+module Devise
+  def self.mappings
+    # Starting from Rails 8.0, routes are lazy-loaded by default in test and development environments.
+    # However, Devise's mappings are built during the routes loading phase.
+    # To ensure it works correctly, we need to load the routes first before accessing @@mappings.
+    Rails.application.try(:reload_routes_unless_loaded)
+    @@mappings
+  end
+end


### PR DESCRIPTION
Rails8から開発環境とテスト環境でroutesが遅延ロードされるようになったことにより、Deviseでマッピングエラーが発生するようになったため修正した。